### PR TITLE
subscription fix

### DIFF
--- a/app/controllers/spree/subscriptions_controller.rb
+++ b/app/controllers/spree/subscriptions_controller.rb
@@ -43,7 +43,7 @@ class Spree::SubscriptionsController < Spree::BaseController
   private
 
     def gibbon
-	@gibbon ||= Gibbon.new(Spree::Config.get(:mailchimp_api_key))mailchimp_api_key	
+	@gibbon ||= Gibbon.new(Spree::Config.get(:mailchimp_api_key))	
     end
 
 end


### PR DESCRIPTION
Compare line 46 of https://github.com/bluehandtalking/spree_mailchimp_gibbon/blob/master/app/controllers/spree/subscriptions_controller.rb

between master and 1-3-stable. On 1-3-stable there appears to be a mistake - the line reads
`@gibbon ||= Gibbon.new(Spree::Config.get(:mailchimp_api_key))mailchimp_api_key`
This ran fine on my development build, but when I deployed to production, it didn't fly.
It seems to be a trivial problem that's somehow made it into the 1-3-stable branch. The line should, of course, read 
`@gibbon ||= Gibbon.new(Spree::Config.get(:mailchimp_api_key))`

I'm submitting a pull request for this issue.
