### PR TITLE
Fixed an error when the signing user already exists in mailchimp

### DIFF
--- a/app/controllers/spree/subscriptions_controller.rb
+++ b/app/controllers/spree/subscriptions_controller.rb
@@ -43,7 +43,7 @@ class Spree::SubscriptionsController < Spree::BaseController
   private
 
     def gibbon
-	@gibbon ||= Gibbon.new(Spree::Config.get(:mailchimp_api_key))	
+	    @gibbon ||= Gibbon.new(Spree::Config.get(:mailchimp_api_key))	
     end
 
 end


### PR DESCRIPTION
Hi!

If a subscriber already exists in mailchimp, and then attempts to sign up with the same email address (and checks the option to subscribe), currently, they get shown an error page and the signup fails.

This fix checks mailchimp to see if the subscriber already exists, and if they do, we get thei subscriber id form mailchimp and update the database with it.

I encountered this problem when importing a list of old subscribers into mailchimp; users who had subscribed to the newsletter on the old site were unable to sign up if they checked 'subscribe to newsletter'.

Hope this helps.

Fareed
